### PR TITLE
Do not automatically close connection when connection is set to "failed" state

### DIFF
--- a/lib/negotiator.ts
+++ b/lib/negotiator.ts
@@ -97,11 +97,11 @@ export class Negotiator<
 					logger.log(
 						"iceConnectionState is failed, closing connections to " + peerId,
 					);
-					this.connection.emitError(
-						BaseConnectionErrorType.NegotiationFailed,
-						"Negotiation of connection to " + peerId + " failed.",
-					);
-					this.connection.close();
+					// this.connection.emitError(
+					// 	BaseConnectionErrorType.NegotiationFailed,
+					// 	"Negotiation of connection to " + peerId + " failed.",
+					// );
+					// this.connection.close();
 					break;
 				case "closed":
 					logger.log(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@deadsetbit/peerjs",
-	"version": "1.5.4",
+	"version": "1.5.4-fork.0",
 	"keywords": [
 		"peerjs",
 		"webrtc",


### PR DESCRIPTION
This should be for the app to decide.

As our peer to peer connection may consist of more than one peer connection at a time, we want to control the closing of these connections  and only when all connections are closed consider the peers as fully "closed".